### PR TITLE
Automatically flush previous round data

### DIFF
--- a/client/src/components/CentralDisplay.js
+++ b/client/src/components/CentralDisplay.js
@@ -432,6 +432,7 @@ export default function CentralDisplay() {
   const [scoringLoading, setScoringLoading] = useState(false);
   const waitingContainerRef = useRef(null);
   const [playerBoxes, setPlayerBoxes] = useState([]);
+  const previousPhaseRef = useRef();
   
   // Update player box positions for flocking birds
   useEffect(() => {
@@ -503,6 +504,8 @@ export default function CentralDisplay() {
       setTimer(duration);
       setPrompts({});
       setImages({});
+      setGptScoring(null);
+      setScoringLoading(false);
     });
 
     newSocket.on('timer-update', (timeLeft) => {
@@ -545,6 +548,22 @@ export default function CentralDisplay() {
       newSocket.close();
     };
   }, []);
+
+  useEffect(() => {
+    const previousPhase = previousPhaseRef.current;
+    const currentPhase = gameState?.phase;
+
+    if (currentPhase && currentPhase !== previousPhase) {
+      if (currentPhase === 'ready' || currentPhase === 'waiting') {
+        setPrompts({});
+        setImages({});
+        setGptScoring(null);
+        setScoringLoading(false);
+      }
+    }
+
+    previousPhaseRef.current = currentPhase;
+  }, [gameState?.phase]);
   
   // Generate QR code for next player when someone wins (but only once per game)
   useEffect(() => {

--- a/client/src/components/PlayerInterface.js
+++ b/client/src/components/PlayerInterface.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import io from 'socket.io-client';
 
 // Dynamic socket URL that works for both local and network access
@@ -31,6 +31,7 @@ export default function PlayerInterface({ playerId }) {
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState(null);
   const [timer, setTimer] = useState(0);
+  const previousPhaseRef = useRef();
 
   useEffect(() => {
     const socketURL = getSocketURL();
@@ -59,6 +60,7 @@ export default function PlayerInterface({ playerId }) {
 
     newSocket.on('battle-started', ({ duration }) => {
       setTimer(duration);
+      setPrompt('');
     });
 
     newSocket.on('timer-update', (timeLeft) => {
@@ -83,6 +85,19 @@ export default function PlayerInterface({ playerId }) {
       newSocket.close();
     };
   }, [playerId]);
+
+  useEffect(() => {
+    const previousPhase = previousPhaseRef.current;
+    const currentPhase = gameState?.phase;
+
+    if (currentPhase && currentPhase !== previousPhase) {
+      if (currentPhase === 'ready' || currentPhase === 'waiting') {
+        setPrompt('');
+      }
+    }
+
+    previousPhaseRef.current = currentPhase;
+  }, [gameState?.phase]);
 
   const handlePromptChange = useCallback((e) => {
     const value = e.target.value;

--- a/server.js
+++ b/server.js
@@ -253,6 +253,18 @@ io.on('connection', (socket) => {
     } else {
       gameState.target = target;
     }
+
+    // Clear out previous round data so the new round starts fresh
+    Object.keys(gameState.players).forEach(playerId => {
+      if (gameState.players[playerId]) {
+        gameState.players[playerId].ready = false;
+      }
+    });
+    gameState.prompts = {};
+    gameState.generatedImages = {};
+    gameState.winner = null;
+    gameState.timer = 0;
+
     gameState.phase = 'ready';
     io.emit('game-state', gameState);
   });


### PR DESCRIPTION
## Summary
- clear player readiness, prompts, generated images, and timers when a new target is set so each round starts clean
- reset player interfaces when phases return to waiting/ready or a battle begins
- clear central display prompts, images, and GPT scoring when a new round starts

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68dc8547ee908322a8979665e06bde19