### PR TITLE
Refactor socket utilities into shared module

### DIFF
--- a/client/src/components/AdminPanel.js
+++ b/client/src/components/AdminPanel.js
@@ -1,28 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Settings, Play, RotateCcw, Timer, Users, Monitor } from 'lucide-react';
 import io from 'socket.io-client';
-
-const getSocketURL = () => {
-  const protocol = window.location.protocol;
-  const hostname = window.location.hostname;
-  const port = process.env.NODE_ENV === 'production' ? window.location.port : '3001';
-  return `${protocol}//${hostname}:${port}`;
-};
-
-// Convert OpenAI image URLs to use our proxy endpoint
-const getProxiedImageUrl = (originalUrl) => {
-  if (!originalUrl) return originalUrl;
-
-  // Only proxy OpenAI URLs, leave other URLs as-is
-  if (originalUrl.startsWith('https://oaidalleapiprodscus.blob.core.windows.net/')) {
-    const baseUrl = process.env.NODE_ENV === 'production'
-      ? window.location.origin
-      : `${window.location.protocol}//${window.location.hostname}:3001`;
-    return `${baseUrl}/api/proxy-image?url=${encodeURIComponent(originalUrl)}`;
-  }
-
-  return originalUrl;
-};
+import { getSocketURL, getProxiedImageUrl } from '../utils/network';
 
 export default function AdminPanel() {
   const [socket, setSocket] = useState(null);

--- a/client/src/components/CentralDisplay.js
+++ b/client/src/components/CentralDisplay.js
@@ -1,28 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import io from 'socket.io-client';
 import QRCode from 'qrcode';
-
-const getSocketURL = () => {
-  const protocol = window.location.protocol;
-  const hostname = window.location.hostname;
-  const port = process.env.NODE_ENV === 'production' ? window.location.port : '3001';
-  return `${protocol}//${hostname}:${port}`;
-};
-
-// Convert OpenAI image URLs to use our proxy endpoint
-const getProxiedImageUrl = (originalUrl) => {
-  if (!originalUrl) return originalUrl;
-
-  // Only proxy OpenAI URLs, leave other URLs as-is
-  if (originalUrl.startsWith('https://oaidalleapiprodscus.blob.core.windows.net/')) {
-    const baseUrl = process.env.NODE_ENV === 'production'
-      ? window.location.origin
-      : `${window.location.protocol}//${window.location.hostname}:3001`;
-    return `${baseUrl}/api/proxy-image?url=${encodeURIComponent(originalUrl)}`;
-  }
-
-  return originalUrl;
-};
+import { getSocketURL, getProxiedImageUrl } from '../utils/network';
 
 // Flocking Birds Component
 const FlockingBirds = ({ playerBoxes }) => {

--- a/client/src/components/PlayerInterface.js
+++ b/client/src/components/PlayerInterface.js
@@ -1,28 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import io from 'socket.io-client';
-
-// Dynamic socket URL that works for both local and network access
-const getSocketURL = () => {
-  const protocol = window.location.protocol;
-  const hostname = window.location.hostname;
-  const port = process.env.NODE_ENV === 'production' ? window.location.port : '3001';
-  return `${protocol}//${hostname}:${port}`;
-};
-
-// Convert OpenAI image URLs to use our proxy endpoint
-const getProxiedImageUrl = (originalUrl) => {
-  if (!originalUrl) return originalUrl;
-
-  // Only proxy OpenAI URLs, leave other URLs as-is
-  if (originalUrl.startsWith('https://oaidalleapiprodscus.blob.core.windows.net/')) {
-    const baseUrl = process.env.NODE_ENV === 'production'
-      ? window.location.origin
-      : `${window.location.protocol}//${window.location.hostname}:3001`;
-    return `${baseUrl}/api/proxy-image?url=${encodeURIComponent(originalUrl)}`;
-  }
-
-  return originalUrl;
-};
+import { getSocketURL, getProxiedImageUrl } from '../utils/network';
 
 export default function PlayerInterface({ playerId }) {
   const [socket, setSocket] = useState(null);

--- a/client/src/utils/network.js
+++ b/client/src/utils/network.js
@@ -1,0 +1,19 @@
+export const getSocketURL = () => {
+  const protocol = window.location.protocol;
+  const hostname = window.location.hostname;
+  const port = process.env.NODE_ENV === 'production' ? window.location.port : '3001';
+  return `${protocol}//${hostname}:${port}`;
+};
+
+export const getProxiedImageUrl = (originalUrl) => {
+  if (!originalUrl) return originalUrl;
+
+  if (originalUrl.startsWith('https://oaidalleapiprodscus.blob.core.windows.net/')) {
+    const baseUrl = process.env.NODE_ENV === 'production'
+      ? window.location.origin
+      : `${window.location.protocol}//${window.location.hostname}:3001`;
+    return `${baseUrl}/api/proxy-image?url=${encodeURIComponent(originalUrl)}`;
+  }
+
+  return originalUrl;
+};


### PR DESCRIPTION
## Summary
- extract the socket URL and image proxy helpers into a shared utility module
- update AdminPanel, CentralDisplay, and PlayerInterface to consume the shared helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dca666dd888322946283721f9e3b28